### PR TITLE
Fixes in docker-compose deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,4 @@ RUN mkdir cache user_agents scraped
 RUN poetry install
 RUN echo LOOKYLOO_HOME="'`pwd`'" > .env
 RUN poetry run tools/3rdparty.py
+RUN poetry run tools/generate_sri.py

--- a/bin/background_indexer.py
+++ b/bin/background_indexer.py
@@ -3,6 +3,7 @@
 import logging
 import os
 from datetime import datetime, timedelta
+import shutil
 
 from lookyloo.default import AbstractManager
 from lookyloo.exceptions import MissingUUID, NoValidHarFile
@@ -61,7 +62,7 @@ class BackgroundIndexer(AbstractManager):
                 self.logger.warning(f'Unable to build pickle for {uuid}: {uuid_path.parent.name}')
                 # The capture is not working, moving it away.
                 self.lookyloo.redis.hdel('lookup_dirs', uuid)
-                uuid_path.parent.rename(self.discarded_captures_dir / uuid_path.parent.name)
+                shutil.move(uuid_path.parent, (self.discarded_captures_dir / uuid_path.parent.name))
 
     def _check_indexes(self):
         index_redis = self.lookyloo.indexing.redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
         - ./cache:/lookyloo/cache
         - ./indexing:/lookyloo/indexing
         - ./scraped:/lookyloo/scraped
+        - ./discarded:/lookyloo/discarded_captures
         - ./user_agents:/lookyloo/user_agents
         - ./config:/lookyloo/config
     ports:


### PR DESCRIPTION
Pull requests should be opened against the `main` branch. For more information on contributing to Lookyloo documentation, see the [Contributor Guidelines](https://www.lookyloo.eu/docs/main/contributor-guide.html).

## Type of change

**Description:**

- docker-compose.yml file was missing discarded captures directory volume
- background-indexer was using path.rename which doesn't support moving files across devices (ie. docker volumes), using shutil for that
- SRI generator script wasn't run in the Dockerfile

**Select the type of change(s) made in this pull request:**
- [x] Bug fix *(non-breaking change which fixes an issue)*
- [ ] New feature *(non-breaking change which adds functionality)*
- [ ] Documentation *(change or fix to documentation)*