### PR TITLE
Fix for Dockerfile smell DL3008

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update
 RUN apt-get -y upgrade
-RUN apt-get -y install wget python3-dev git python3-venv python3-pip python-is-python3
-RUN apt-get -y install libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 libxkbcommon0 libxdamage1 libgbm1 libpango-1.0-0 libcairo2 libatspi2.0-0
-RUN apt-get -y install libxcomposite1 libxfixes3 libxrandr2 libasound2
+RUN apt-get -y install wget=1.21.* python3-dev=3.10.* git=1:2.34.* python3-venv=3.10.* python3-pip=22.0.* python-is-python3=3.9.* 
+RUN apt-get -y install libnss3=2:3.68.* libnspr4=2:4.32-* libatk1.0-0=2.36.* libatk-bridge2.0-0=2.38.* libcups2=2.4.* libxkbcommon0=1.4.* libxdamage1=1:1.1.* libgbm1=22.2.* libpango-1.0-0=1.50.* libcairo2=1.16.* libatspi2.0-0=2.44.* 
+RUN apt-get -y install libxcomposite1=1:0.4.* libxfixes3=1:6.0.* libxrandr2=2:1.5.* libasound2=1.2.* 
 RUN pip3 install poetry
 
 WORKDIR lookyloo


### PR DESCRIPTION
Pull requests should be opened against the `main` branch. For more information on contributing to Lookyloo documentation, see the [Contributor Guidelines](https://www.lookyloo.eu/docs/main/contributor-guide.html).

## Type of change

**Description:**
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3008](https://github.com/hadolint/hadolint/wiki/DL3008) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3008 occurs when the version pinning for the installed packages with apt is not specified. This could lead to unexpected behavior when building the Dockerfile.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for a given apt package corresponding to the latest version at the current date. The package versions are retrieved using the Canonical Launchpad APIs.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance

**Select the type of change(s) made in this pull request:**
- [x] Bug fix *(non-breaking change which fixes an issue)*
- [ ] New feature *(non-breaking change which adds functionality)*
- [ ] Documentation *(change or fix to documentation)*

---------------------------------------------------------------------------------------------------------

Fixes #issue-number


## Proposed changes <!-- Describe the changes the PR makes. -->

* Version pinning for installed apt packages
