### PR TITLE
Proxy with VT module

### DIFF
--- a/config/modules.json.sample
+++ b/config/modules.json.sample
@@ -1,6 +1,7 @@
 {
   "VirusTotal": {
     "apikey": null,
+    "trustenv": false,
     "autosubmit": false,
     "allow_auto_trigger": false
   },

--- a/lookyloo/modules/vt.py
+++ b/lookyloo/modules/vt.py
@@ -33,7 +33,7 @@ class VirusTotal(AbstractModule):
             self.logger.info('Not enabled')
             return False
 
-        self.client = vt.Client(self.config['apikey'])
+        self.client = vt.Client(self.config['apikey'], trustenv=bool(self.config['trustenv'], False))
 
         self.allow_auto_trigger = bool(self.config.get('allow_auto_trigger', False))
         self.autosubmit = bool(self.config.get('autosubmit', False))


### PR DESCRIPTION
## Type of change

Modified the vt.py module so that the vt.Client reads the `trustenv` parameter from the module's config section if present. 

Current functionality sees the `trustenv` parameter to vt.Client default to `False`. Unless the new config parameter is used, `False` remains the default.


**Select the type of change(s) made in this pull request:**
- [ x] Bug fix *(non-breaking change which fixes an issue)*
- [ ] New feature *(non-breaking change which adds functionality)*
- [ ] Documentation *(change or fix to documentation)*

---------------------------------------------------------------------------------------------------------

Fixes #896 


## Proposed changes 

* add a `trustenv` parameter to the vt module's config
* modified vt module to read and use a `trustenv` parameter from the module config file (if present)
