### PR TITLE
Takedown information filter

### DIFF
--- a/config/email.tmpl
+++ b/config/email.tmpl
@@ -7,6 +7,8 @@ Initial URL: {initial_url}
 
 {redirects}
 
+{misp}
+
 {comment}
 
 

--- a/lookyloo/lookyloo.py
+++ b/lookyloo/lookyloo.py
@@ -9,6 +9,7 @@ import gzip
 import json
 import logging
 import operator
+import shutil
 import re
 import smtplib
 import ssl

--- a/lookyloo/modules/misp.py
+++ b/lookyloo/modules/misp.py
@@ -251,7 +251,7 @@ class MISP(AbstractModule):
             return event
         return None
 
-    def lookup(self, node: URLNode, hostnode: HostNode) -> dict[str, set[str]] | dict[str, Any]:
+    def lookup(self, node: URLNode, hostnode: HostNode, time: bool=False) -> dict[str, set[str]] | dict[str, Any]:
         if self.available and self.enable_lookup:
             tld = self.psl.publicsuffix(hostnode.name)
             domain = re.sub(f'.{tld}$', '', hostnode.name).split('.')[-1]
@@ -271,6 +271,8 @@ class MISP(AbstractModule):
                     # NOTE: We have MISPAttribute in that list
                     for a in attributes:
                         to_return[a.event_id].add(a.value)  # type: ignore[union-attr,index]
+                        if time:
+                            to_return[a.event_id].add(a.timestamp)
                     return to_return
                 else:
                     # The request returned an error


### PR DESCRIPTION
Pull requests should be opened against the `main` branch. For more information on contributing to Lookyloo documentation, see the [Contributor Guidelines](https://www.lookyloo.eu/docs/main/contributor-guide.html).

## Type of change

**Description:**
Adding the MISP lookup. When an URL was submitted to MISP during the last 24h, it is shown in the report email (timestamp + link to the MISP event).
Emails and domains from the takedown information are now filtered/or replaced.


**Select the type of change(s) made in this pull request:**
- [ ] Bug fix *(non-breaking change which fixes an issue)*
- [ x] New feature *(non-breaking change which adds functionality)*
- [ ] Documentation *(change or fix to documentation)*

---------------------------------------------------------------------------------------------------------

Fixes #900 #901 


## Proposed changes <!-- Describe the changes the PR makes. -->

*
*
*
